### PR TITLE
Allow setting expression directly

### DIFF
--- a/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
@@ -32,7 +32,7 @@ private func generateStyleProperty(for attributes: AttributeSyntax, valueType: T
         valueType: valueType,
         isRawRepresentable: isRawRepresentable
     )
-    
+
     let nsExpressionFuncDecl = try FunctionDeclSyntax("public func \(identifier)(expression: NSExpression) -> Self") {
         "var copy = self"
         "copy.\(identifier) = expression"

--- a/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
@@ -25,13 +25,19 @@ private func generateStyleProperty(for attributes: AttributeSyntax, valueType: T
 
     let identifier = TokenSyntax(stringLiteral: identifierString)
 
-    let varDeclSyntax = DeclSyntax("public var \(identifier): NSExpression? = nil")
+    let varDeclSyntax = DeclSyntax("fileprivate var \(identifier): NSExpression? = nil")
 
     let constantFuncDecl = try generateFunctionDeclSyntax(
         identifier: identifier,
         valueType: valueType,
         isRawRepresentable: isRawRepresentable
     )
+    
+    let nsExpressionFuncDecl = try FunctionDeclSyntax("public func \(identifier)(expression: NSExpression) -> Self") {
+        "var copy = self"
+        "copy.\(identifier) = expression"
+        "return copy"
+    }
 
     let getPropFuncDecl =
         try FunctionDeclSyntax("public func \(identifier)(featurePropertyNamed keyPath: String) -> Self") {
@@ -41,7 +47,8 @@ private func generateStyleProperty(for attributes: AttributeSyntax, valueType: T
         }
 
     guard let constFuncDeclSyntax = DeclSyntax(constantFuncDecl),
-          let getPropFuncDeclSyntax = DeclSyntax(getPropFuncDecl)
+          let getPropFuncDeclSyntax = DeclSyntax(getPropFuncDecl),
+          let nsExpressionFuncDeclSyntax = DeclSyntax(nsExpressionFuncDecl)
     else {
         fatalError("SwiftSyntax bug or implementation error: unable to construct DeclSyntax")
     }
@@ -65,7 +72,7 @@ private func generateStyleProperty(for attributes: AttributeSyntax, valueType: T
         extra.append(interpolationFuncDeclSyntax)
     }
 
-    return [varDeclSyntax, constFuncDeclSyntax, getPropFuncDeclSyntax] + extra
+    return [varDeclSyntax, constFuncDeclSyntax, nsExpressionFuncDeclSyntax, getPropFuncDeclSyntax] + extra
 }
 
 private func generateFunctionDeclSyntax(identifier: TokenSyntax, valueType: TypeSyntax,

--- a/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
+++ b/Sources/MapLibreSwiftMacrosImpl/StyleExpressionMacro.swift
@@ -25,7 +25,7 @@ private func generateStyleProperty(for attributes: AttributeSyntax, valueType: T
 
     let identifier = TokenSyntax(stringLiteral: identifierString)
 
-    let varDeclSyntax = DeclSyntax("fileprivate var \(identifier): NSExpression? = nil")
+    let varDeclSyntax = DeclSyntax("public var \(identifier): NSExpression? = nil")
 
     let constantFuncDecl = try generateFunctionDeclSyntax(
         identifier: identifier,

--- a/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
+++ b/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
@@ -41,7 +41,7 @@ final class ExpressionTests: XCTestCase {
                         copy.backgroundColor = NSExpression(forConstantValue: value)
                         return copy
                     }
-                
+
                     public func backgroundColor(expression: NSExpression) -> Self {
                         var copy = self
                         copy.backgroundColor = expression
@@ -74,7 +74,7 @@ final class ExpressionTests: XCTestCase {
                         copy.backgroundColor = NSExpression(forConstantValue: value)
                         return copy
                     }
-                
+
                     public func backgroundColor(expression: NSExpression) -> Self {
                         var copy = self
                         copy.backgroundColor = expression
@@ -113,7 +113,7 @@ final class ExpressionTests: XCTestCase {
                         copy.backgroundColor = NSExpression(forConstantValue: value)
                         return copy
                     }
-                
+
                     public func backgroundColor(expression: NSExpression) -> Self {
                         var copy = self
                         copy.backgroundColor = expression
@@ -164,7 +164,7 @@ final class ExpressionTests: XCTestCase {
                         copy.backgroundColor = expression
                         return copy
                     }
-                
+
                     public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
                         var copy = self
                         copy.backgroundColor = NSExpression(forKeyPath: keyPath)

--- a/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
+++ b/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
@@ -34,7 +34,7 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    fileprivate var backgroundColor: NSExpression? = nil
+                    public var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
@@ -61,7 +61,7 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    fileprivate var backgroundColor: NSExpression? = nil
+                    public var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
@@ -94,7 +94,7 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    fileprivate var backgroundColor: NSExpression? = nil
+                    public var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
@@ -133,7 +133,7 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    fileprivate var backgroundColor: NSExpression? = nil
+                    public var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self

--- a/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
+++ b/Tests/MapLibreSwiftMacrosTests/MapLibreSwiftMacrosTests.swift
@@ -34,11 +34,17 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    public var backgroundColor: NSExpression? = nil
+                    fileprivate var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
                         copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+                
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
                         return copy
                     }
 
@@ -61,11 +67,17 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    public var backgroundColor: NSExpression? = nil
+                    fileprivate var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
                         copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+                
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
                         return copy
                     }
 
@@ -94,11 +106,17 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    public var backgroundColor: NSExpression? = nil
+                    fileprivate var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
                         copy.backgroundColor = NSExpression(forConstantValue: value)
+                        return copy
+                    }
+                
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
                         return copy
                     }
 
@@ -133,7 +151,7 @@ final class ExpressionTests: XCTestCase {
                 """
                 struct Layer {
 
-                    public var backgroundColor: NSExpression? = nil
+                    fileprivate var backgroundColor: NSExpression? = nil
 
                     public func backgroundColor(_ value: UIColor) -> Self {
                         var copy = self
@@ -141,6 +159,12 @@ final class ExpressionTests: XCTestCase {
                         return copy
                     }
 
+                    public func backgroundColor(expression: NSExpression) -> Self {
+                        var copy = self
+                        copy.backgroundColor = expression
+                        return copy
+                    }
+                
                     public func backgroundColor(featurePropertyNamed keyPath: String) -> Self {
                         var copy = self
                         copy.backgroundColor = NSExpression(forKeyPath: keyPath)


### PR DESCRIPTION
For more advanced use cases, developers may wish to specify NSExpressions directly, for example to show the number of clustered pins in a symbol layer.

This PR allows the setting of NSExpressions directly for advanced use cases, while keeping the convenience of value based modifiers.

This will allow use cases like the one below (separate PR for clustering and text symbol support coming up for Maplibre DSL)

<img width="794" alt="Screenshot 2024-04-25 at 19 09 43" src="https://github.com/stadiamaps/maplibre-swift-macros/assets/645674/b0861d6a-5dda-4676-ac84-1b0b60d51f40">
